### PR TITLE
use node-semver to check for compatible ember-cli version

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var fs   = require('fs');
 var path = require('path');
+var semver = require('semver');
 
 module.exports = {
   name: 'Ember CLI Foundation SASS',
@@ -8,7 +9,7 @@ module.exports = {
     this._super.included(app);
     //this.app.import(app.bowerDirectory);
     var emberCLIVersion = app.project.emberCLIVersion();
-    if (emberCLIVersion < '0.1.2') {
+    if (semver.lt(emberCLIVersion, '0.1.2')) {
       throw new Error('ember-cli-foundation-sass requires ember-cli version 0.1.2 or greater.\n');
     }
 

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "license": "MIT",
   "engines": {
     "node": ">= 0.10.0"
+  },
+  "dependencies": {
+    "semver": "^4.2.0"
   }
 }


### PR DESCRIPTION
the new version of ember-cli is 0.1.11

the string compare threw and error and broke `ember serve`.