### PR TITLE
Support ember-cli >= 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### master
 
+* [BUGFIX] Fixed for ember-cli >= 0.2.0
+
 ### 1.0.0
 * [BUGFIX] Fixed for latest ember-cli 0.1.11
 * [BUGFIX] Fixed that new `ember addon:install` command works properly

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = function(environment, appConfig) {
+  if(!appConfig.sassOptions) {
+    appConfig.sassOptions = {};
+  }
+
+  if(!appConfig.sassOptions.includePaths) {
+    appConfig.sassOptions.includePaths = [];
+  }
+
+  appConfig.sassOptions.includePaths.push('bower_components/foundation/scss');
+
+  return {};
+};


### PR DESCRIPTION
sassOptions hash has moved from app.options to ENV hash.