### PR TITLE
update ember-cli-sass dependency to 4.0.1

### DIFF
--- a/blueprints/ember-cli-foundation-sass/index.js
+++ b/blueprints/ember-cli-foundation-sass/index.js
@@ -20,7 +20,7 @@ module.exports = {
     fs.writeFileSync(path.join(stylePath, '_foundation.scss'), fs.readFileSync(mainPath));
 
     return this.addPackagesToProject([
-      { name: 'ember-cli-sass', target: '3.3.1'},
+      { name: 'ember-cli-sass', target: '4.0.1'},
       { name: 'broccoli-clean-css', target: '~1.0.0' }
     ]);
   }


### PR DESCRIPTION
This version can handle outputPaths option correctly http://www.ember-cli.com/#configuring-output-paths and thus provide compatibility with  other plugins, i.e.
```javascript
/* global require, module */

var EmberApp = require('ember-cli/lib/broccoli/ember-app');
var autoprefixer = require('autoprefixer-core');

var app = new EmberApp({
  outputPaths: {
    app: {
      css: {
        'app': '/app/styles/app.css'
      }
    }
  },
  postcssOptions: {
    plugins: [
      {
        module: autoprefixer,
        options: {
          browsers: ['last 2 version']
        }
      }
    ]
  }
});

module.exports = app.toTree();

```
otherwise, postCss and other plugins will throw out an error, because of ember-cli-sass alters default output path for css.